### PR TITLE
Added 'allowedFileTypes' array list to settings. By default now allow…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
                     "type": "string",
                     "default": "",
                     "description": "Set default browser"
+                },
+                "open-in-browser.allowedFileTypes": {
+                    "type": "array",
+                    "default": ["html", "markdown", "json", "plaintext"],
+                    "description": "Set the allowed file types list to be open in browser"
                 }
             }
         },

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -2,7 +2,7 @@ var vscode = require('vscode');
 var util = require('./util');
 var acceptBrowsers = require('./config').acceptBrowsers;
 var isFocused = util.isFocused;
-var isHtml = util.isHtml;
+var isAllowed = util.isAllowed;
 var filePath = util.filePath;
 var openFile = util.openFile;
 var getDefaultBrowser = util.getDefaultBrowser;
@@ -13,8 +13,8 @@ function open () {
     
     let path = filePath();
     
-    if (!isHtml()) {
-        vscode.window.showInformationMessage('[ open-in-browser ]: Sorry, Only HTML File Supported Now ...');
+    if (!isAllowed()) {
+        vscode.window.showInformationMessage('[ open-in-browser ]: Sorry, this file type is not allowed. See your personal settings.');
         return;
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -7,8 +7,12 @@ function isFocused () {
     return !!vscode.window.activeTextEditor;
 }
 
-function isHtml () {
-    return vscode.window.activeTextEditor.document.languageId == 'html';
+/**
+ * return true if the current file type is included in the allowedFileTypes list setting, or if the setting is empty.
+ */
+function isAllowed () {
+    var fileTypes = getAllowedFileTypes();
+    return fileTypes.length ? fileTypes.indexOf(vscode.window.activeTextEditor.document.languageId) > -1 : true;
 }
 
 function filePath ( file ) {
@@ -48,11 +52,24 @@ function getDefaultBrowser () {
 
     return browser;
 }
+/**
+ * get allowed file types as specified in configuration file
+ */
+function getAllowedFileTypes(){
+    let allowedFileTypes = [];
+    let config = vscode.workspace.getConfiguration( 'open-in-browser' );
+
+    if ( config.allowedFileTypes ) {
+        allowedFileTypes = config.allowedFileTypes;
+    }
+
+    return allowedFileTypes;
+}
 
 function openFile ( platform, path, browser ) {
     let cmd;
     let browserName = getStandardBrowserName( browser );
-    console.log(browserName);
+    console.log(browser, browserName, path, platform);
     switch (platform) {
         case 'win32':
             cmd = browserName
@@ -80,7 +97,7 @@ function openFile ( platform, path, browser ) {
 
 module.exports = {
     isFocused: isFocused,
-    isHtml: isHtml,
+    isAllowed: isAllowed,
     filePath: filePath,
     openFile: openFile,
     getDefaultBrowser: getDefaultBrowser


### PR DESCRIPTION
This modification add a user settings option called ```allowedFileTypes```, as an array of allowed file types.
- The plugin will only open file types in the list.
- If the list is empty, then the plugin will allow any file type to open.
- By default the allowed file types are: 
  - HTML
  - Plain Text
  - JSON 
  - Markdown

Regards!!